### PR TITLE
fix enum

### DIFF
--- a/src/dumper.ts
+++ b/src/dumper.ts
@@ -4,6 +4,7 @@ import { CodeModel, Info, ObjectSchema, Operation, Parameter, OperationGroup, Pr
 import { isNullOrUndefined, isString, isArray, isObject, isUndefined, isNull } from 'util';
 import { keys } from '@azure-tools/linq';
 import { NodeExtensionHelper, NodeHelper, NodeCliHelper } from './nodeHelper';
+import { Helper } from './helper';
 
 export class Dumper {
     private debugEnabled = false;
@@ -163,7 +164,7 @@ export class Dumper {
             output.push(Dumper.tab(indent + 1) + 'readOnly: true');
         }
 
-        if (parameter.schema instanceof ObjectSchema && NodeHelper.HasSubClass(parameter.schema)) {
+        if (Helper.isObjectSchema(parameter.schema) && NodeHelper.HasSubClass(parameter.schema as ObjectSchema)) {
             output.push(Dumper.tab(indent + 1) + NodeHelper.DISCRIMINATOR_FLAG + ': true');
         }
 
@@ -203,7 +204,7 @@ export class Dumper {
             output.push(Dumper.tab(indent + 1) + 'readOnly: true');
         }
 
-        if (parameter.schema instanceof ObjectSchema && NodeHelper.HasSubClass(parameter.schema)) {
+        if (Helper.isObjectSchema(parameter.schema) && NodeHelper.HasSubClass(parameter.schema as ObjectSchema)) {
             output.push(Dumper.tab(indent + 1) + NodeHelper.DISCRIMINATOR_FLAG + ': true');
         }
 
@@ -313,9 +314,9 @@ export class Dumper {
             return o;
         else if (isArray(o))
             return o.map(v => Dumper.NEW_LINE + Dumper.tab(indent) + "- " + Dumper.formatValue(v, indent + 2/* one more indent for array*/)).join('');
-        else if (o instanceof ObjectSchema)
+        else if (Helper.isObjectSchema(o))
             return `<${(o as ObjectSchema).language.default.name}>`;
-        else if (o instanceof Operation)
+        else if (Helper.isOperation(o))
             return `<${(o as Operation).language.default.name}>`;
         else if (isObject(o))
             return keys(o).select(k => Dumper.NEW_LINE + Dumper.tab(indent) + `${k}: ${Dumper.formatValue(o[k], indent + 1)}`).join('');

--- a/src/flattenHelper.ts
+++ b/src/flattenHelper.ts
@@ -1,12 +1,13 @@
 import { getAllProperties, ImplementationLocation, ObjectSchema, Parameter, Property, Request, VirtualParameter } from "@azure-tools/codemodel";
 import { values } from "@azure-tools/linq";
 import { isNullOrUndefined } from "util";
+import { Helper } from "./helper";
 import { NodeExtensionHelper, NodeCliHelper } from "./nodeHelper";
 
 export class FlattenHelper {
 
     public static flattenParameter(req: Request, param: Parameter, path: Property[], prefix: string): void {
-        if (!(param.schema instanceof ObjectSchema))
+        if (!Helper.isObjectSchema(param.schema))
             throw Error(`Try to flatten non-object schema: param = '${param.language.default.name}', schema= '${param.schema.language.default.name}'`);
 
         FlattenHelper.flattenPorperties(req, param, param.schema as ObjectSchema, path, prefix);

--- a/src/flattenHelper.ts
+++ b/src/flattenHelper.ts
@@ -50,6 +50,13 @@ export class FlattenHelper {
         }
 
         vp.required = parameter.required && property.required;
+        if (NodeCliHelper.getHidden(property.schema, false)) {
+            NodeCliHelper.setHidden(vp, true);
+        }
+        const cliDefaultValue = NodeCliHelper.getCliDefaultValue(property.schema);
+        if (cliDefaultValue !== undefined) {
+            NodeCliHelper.setCliDefaultValue(vp, cliDefaultValue);
+        }
 
         yield vp;
     }

--- a/src/flattenHelper.ts
+++ b/src/flattenHelper.ts
@@ -49,6 +49,8 @@ export class FlattenHelper {
             (vp.extensions = vp.extensions || {})['x-ms-parameter-grouping'] = parameter.extensions?.['x-ms-parameter-grouping'];
         }
 
+        vp.required = parameter.required && property.required;
+
         yield vp;
     }
 

--- a/src/nodeHelper.ts
+++ b/src/nodeHelper.ts
@@ -410,15 +410,15 @@ export class NodeHelper {
 
         for (const key in allSubs) {
             const subClass = allSubs[key];
-            if (!(subClass instanceof ObjectSchema)) {
+            if (!Helper.isObjectSchema(subClass)) {
                 Helper.logWarning("subclass is not ObjectSchema: " + subClass.language.default.name);
                 continue;
             }
-            if (NodeHelper.HasSubClass(subClass) && leafOnly) {
+            if (NodeHelper.HasSubClass(subClass as ObjectSchema) && leafOnly) {
                 Helper.logWarning("skip subclass which also has subclass: " + subClass.language.default.name);
                 continue;
             }
-            yield subClass;
+            yield subClass as ObjectSchema;
         }
     }
 
@@ -435,7 +435,9 @@ export class NodeHelper {
     }
 
     public static getDefaultNameWithType(node: ObjectSchema | DictionarySchema | ArraySchema): string {
-        return `${node.language.default.name}(${node instanceof ObjectSchema ? node.type : node instanceof DictionarySchema ? (node.elementType.language.default.name + '^dictionary') : (node.elementType.language.default.name + '^array')})`;
+        return `${node.language.default.name}(${Helper.isObjectSchema(node) ? node.type : 
+            Helper.isDictionarySchema(node) ? ((<DictionarySchema>node).elementType.language.default.name + '^dictionary') : 
+            ((<ArraySchema>node).elementType.language.default.name + '^array')})`;
     }
 
     public static checkVisibility(prop: Property): boolean {

--- a/src/nodeHelper.ts
+++ b/src/nodeHelper.ts
@@ -10,7 +10,7 @@ export class NodeCliHelper {
     public static readonly POLY_RESOURCE: string = 'poly-resource';
     public static readonly CLI_FLATTEN: string = 'cli-flatten';
     public static readonly SPLIT_OPERATION_NAMES = 'split-operation-names';
-
+    
     private static readonly CLI: string = "cli";
     private static readonly NAME: string = "name";
     private static readonly DESCRIPTION: string = "description";
@@ -23,7 +23,8 @@ export class NodeCliHelper {
     private static readonly CLI_MARK: string = "cli-mark";
     private static readonly CLI_IS_VISIBLE: string = "cli-is-visible";
     private static readonly CLI_OPERATION_SPLITTED = 'cli-operation-splitted';
-    private static readonly JSON: string = "json";
+    private static readonly CLI_DEFAULT_VALUE: string = "default-value";
+
 
     private static readonly POLY_AS_PARAM_EXPANDED = 'cli-poly-as-param-expanded';
 
@@ -145,6 +146,15 @@ export class NodeCliHelper {
 
     public static getIsVisibleFlag(node: M4Node): CliCommonSchema.CodeModel.Visibility {
         return NodeCliHelper.getCliProperty(node, NodeCliHelper.CLI_IS_VISIBLE, () => undefined);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    public static setCliDefaultValue(node: M4Node, value: any): void {
+        NodeCliHelper.setCliProperty(node, NodeCliHelper.CLI_DEFAULT_VALUE, value);
+    }
+
+    public static getCliDefaultValue(node: M4Node): any {
+        return NodeCliHelper.getCliProperty(node, NodeCliHelper.CLI_DEFAULT_VALUE, () => undefined);
     }
 
     /**

--- a/src/plugins/complexMarker.ts
+++ b/src/plugins/complexMarker.ts
@@ -211,7 +211,7 @@ class ComplexMarker {
 
     public process(): void {
 
-        this.session.model.schemas.objects.forEach(obj => {
+        this.session.model.schemas.objects?.forEach(obj => {
             NodeCliHelper.clearComplex(obj);
             NodeCliHelper.clearSimplifyIndicator(obj);
             NodeCliHelper.clearMark(obj);
@@ -228,7 +228,7 @@ class ComplexMarker {
         });
 
         let tag = 1;
-        this.session.model.schemas.objects.forEach(obj => {
+        this.session.model.schemas.objects?.forEach(obj => {
             this.calculateObject(obj);
             tag++;
         });
@@ -241,12 +241,12 @@ class ComplexMarker {
             tag++;
         });
 
-        this.session.model.schemas.objects.forEach(obj => {
+        this.session.model.schemas.objects?.forEach(obj => {
             this.setSimplifyIndicator(obj);
             tag++;
         });
 
-        this.session.model.schemas.objects.forEach(obj => {
+        this.session.model.schemas.objects?.forEach(obj => {
             this.setInCircle(obj, [], tag.toString());
             tag++;
         });

--- a/src/plugins/flattenModifier.ts
+++ b/src/plugins/flattenModifier.ts
@@ -109,7 +109,7 @@ export class FlattenModifier {
     private flattenNormalOperationParam(request: Request, index: number): boolean {
         const parameter = request.parameters[index];
         const paramSchema = parameter.schema;
-        if (!(paramSchema instanceof ObjectSchema)) {
+        if (!Helper.isObjectSchema(paramSchema)) {
             Helper.logWarning(`flatten param ${NodeCliHelper.getCliKey(parameter, null)} is not object! Skip flatten`);
             return false;
         }

--- a/src/plugins/flattenSetter/flattenSetter.ts
+++ b/src/plugins/flattenSetter/flattenSetter.ts
@@ -256,7 +256,7 @@ export class FlattenSetter {
 
         // by default on when the flatten_all flag is one
         if (flattenSchema === true || flattenAll === true) {
-            this.codeModel.schemas.objects.forEach(o => {
+            this.codeModel.schemas.objects?.forEach(o => {
                 if (!NodeHelper.HasSubClass(o)) {
                     for (const p of getAllProperties(o)) {
                         if (isObjectSchema(p.schema)) {
@@ -301,7 +301,7 @@ export class FlattenSetter {
         };
 
         if (flattenPayload === true || flattenAll === true) {
-            this.codeModel.operationGroups.forEach(group => {
+            this.codeModel.operationGroups?.forEach(group => {
                 group.operations.forEach(operation => {
                     values(operation.parameters)
                         .where(p => p.protocol.http?.in === 'body' && p.implementation === 'Method')

--- a/src/plugins/flattenSetter/flattenValidator.ts
+++ b/src/plugins/flattenSetter/flattenValidator.ts
@@ -125,7 +125,7 @@ export class FlattenValidator {
 
         const result: NodePath[] = [];
         const visited = new Set<string>();
-        objects.forEach(o => {
+        objects?.forEach(o => {
             const ni = new NodeInfo(o);
             if (!visited.has(ni.key))
                 this.visitNode(ni, [], result, visited);

--- a/src/plugins/flattenSetter/flattenValidator.ts
+++ b/src/plugins/flattenSetter/flattenValidator.ts
@@ -1,5 +1,5 @@
 import { Session } from "@azure-tools/autorest-extension-base";
-import { CodeModel, isObjectSchema, ObjectSchema, Property } from "@azure-tools/codemodel";
+import { CodeModel, ObjectSchema, Property } from "@azure-tools/codemodel";
 import { isNullOrUndefined } from "util";
 import { Helper } from "../../helper";
 import { NodeHelper, NodeExtensionHelper } from "../../nodeHelper";
@@ -51,7 +51,7 @@ class NodeInfo {
         if (!isNullOrUndefined(this.node.properties) && this.node.properties.length > 0) {
             for (let i = 0; i < this.node.properties.length; i++) {
                 const p = this.node.properties[i];
-                if (isObjectSchema(p.schema)) {
+                if (Helper.isObjectSchema(p.schema)) {
                     NodeExtensionHelper.isFlattened(p) ? this.flattenProperty.push(new PropertyInfo(p)) : this.unflattenProperty.push(new PropertyInfo(p));
                 }
             }

--- a/src/plugins/modelerPostProcessor.ts
+++ b/src/plugins/modelerPostProcessor.ts
@@ -1,8 +1,10 @@
 import { Host, Session } from "@azure-tools/autorest-extension-base";
-import { CodeModel } from "@azure-tools/codemodel";
+import { ChoiceSchema, CodeModel, SealedChoiceSchema, StringSchema } from "@azure-tools/codemodel";
 import { isNullOrUndefined } from "util";
 import { Helper } from "../helper";
 import { CopyHelper } from "../copyHelper";
+import { CliCommonSchema } from "../schema";
+import { NodeCliHelper } from "../nodeHelper";
 
 export class ModelerPostProcessor {
 
@@ -10,13 +12,35 @@ export class ModelerPostProcessor {
     }
 
     public process(): void {
-        Helper.enumerateCodeModel(this.session.model, (n) => {
+        const model = this.session.model;
 
-            // In case cli is shared by multiple instances during modelerfour, do deep copy
+        this.removeCliShare(model);
+
+        this.adjustChoiceschema(model);
+    }
+
+    private removeCliShare(model: CodeModel): void {
+        // In case cli is shared by multiple instances during modelerfour, do deep copy
+        Helper.enumerateCodeModel(model, (n) => {
             if (!isNullOrUndefined(n.target.language['cli'])) {
                 n.target.language['cli'] = CopyHelper.deepCopy(n.target.language['cli']);
             }
         });
+    }
+
+    private adjustChoiceschema(model: CodeModel): void {
+        // For m4 change: https://github.com/Azure/autorest.modelerfour/pull/310/files
+        // If `modelAsString` is not true, it will no longer be regarded as constant, but choice.
+        // To make it backward compatiable, for those choices which are constant before(choice.length === 1),
+        // we give it a default value and set hidden as true.
+        // The following codegen should handle this case.
+        Helper.enumerateCodeModel(model, (n) => {
+            const schema = <ChoiceSchema<StringSchema> | SealedChoiceSchema<StringSchema>>n.target;
+            if (!isNullOrUndefined(schema.choices) && schema.choices.length === 1) {
+                schema.defaultValue = schema.choices[0].value;
+                NodeCliHelper.setHidden(schema, true);
+            }
+        }, CliCommonSchema.CodeModel.NodeTypeFlag.choiceSchema);
     }
 }
 

--- a/src/plugins/modelerPostProcessor.ts
+++ b/src/plugins/modelerPostProcessor.ts
@@ -37,7 +37,7 @@ export class ModelerPostProcessor {
         Helper.enumerateCodeModel(model, (n) => {
             const schema = <ChoiceSchema<StringSchema> | SealedChoiceSchema<StringSchema>>n.target;
             if (!isNullOrUndefined(schema.choices) && schema.choices.length === 1) {
-                schema.defaultValue = schema.choices[0].value;
+                NodeCliHelper.setCliProperty(schema, 'default-value', schema.choices[0].value);
                 NodeCliHelper.setHidden(schema, true);
             }
         }, CliCommonSchema.CodeModel.NodeTypeFlag.choiceSchema);

--- a/src/plugins/polyAsParamModifier.ts
+++ b/src/plugins/polyAsParamModifier.ts
@@ -62,7 +62,7 @@ export class PolyAsParamModifier {
                 if (isNullOrUndefined(request.parameters))
                     return;
                 const allPolyParam: Parameter[] = request.parameters.filter(p =>
-                    p.schema instanceof ObjectSchema &&
+                    Helper.isObjectSchema(p.schema) &&
                     (p.schema as ObjectSchema).discriminator);
                 if (allPolyParam.length == 0)
                     return;
@@ -83,16 +83,16 @@ export class PolyAsParamModifier {
 
                     for (const key in allSubClass) {
                         const subClass = allSubClass[key];
-                        if (!(subClass instanceof ObjectSchema)) {
+                        if (!Helper.isObjectSchema(subClass)) {
                             Helper.logWarning("subclass is not ObjectSchema: " + subClass.language.default.name);
                             continue;
                         }
-                        if (NodeHelper.HasSubClass(subClass)) {
+                        if (NodeHelper.HasSubClass(subClass as ObjectSchema)) {
                             Helper.logWarning("skip subclass which also has subclass: " + subClass.language.default.name);
                             continue;
                         }
 
-                        const param2: Parameter = this.cloneParamForSubclass(polyParam, this.buildSubclassParamName(polyParam, key), subClass);
+                        const param2: Parameter = this.cloneParamForSubclass(polyParam, this.buildSubclassParamName(polyParam, key), subClass as ObjectSchema);
                         NodeExtensionHelper.setPolyAsParamOriginalParam(param2, polyParam);
                         request.addParameter(param2);
                     }

--- a/src/plugins/polyAsResourceModifier.ts
+++ b/src/plugins/polyAsResourceModifier.ts
@@ -129,7 +129,7 @@ export class PolyAsResourceModifier {
             return [];
         }
         return request.parameters?.filter(p =>
-            p.schema instanceof ObjectSchema && (p.schema as ObjectSchema).discriminator && NodeCliHelper.isPolyAsResource(p));
+            Helper.isObjectSchema(p.schema) && (p.schema as ObjectSchema).discriminator && NodeCliHelper.isPolyAsResource(p));
     }
 
     private getDefaultRequest(operation: Operation): Request {

--- a/src/plugins/visibilityCleaner.ts
+++ b/src/plugins/visibilityCleaner.ts
@@ -1,5 +1,5 @@
 import { Host, Session } from "@azure-tools/autorest-extension-base";
-import { CodeModel, ObjectSchema, isObjectSchema, Parameter, ArraySchema, DictionarySchema, ConstantSchema } from "@azure-tools/codemodel";
+import { CodeModel, ObjectSchema, Parameter } from "@azure-tools/codemodel";
 import { Helper } from "../helper";
 import { CliCommonSchema } from "../schema";
 import { NodeHelper, NodeCliHelper } from "../nodeHelper";
@@ -32,14 +32,14 @@ class VisibilityCleaner {
             for (const prop of schema.properties) {
                 if (!NodeHelper.checkVisibility(prop))
                     continue;
-                if (isObjectSchema(prop.schema)) {
-                    if (this.calcObject(prop.schema) === CliCommonSchema.CodeModel.Visibility.true)
+                if (Helper.isObjectSchema(prop.schema)) {
+                    if (this.calcObject(prop.schema as ObjectSchema) === CliCommonSchema.CodeModel.Visibility.true)
                         visible = CliCommonSchema.CodeModel.Visibility.true;
                 }
-                else if ((prop.schema instanceof ArraySchema || prop.schema instanceof DictionarySchema)) {
+                else if (Helper.isArraySchema(prop.schema) || Helper.isDictionarySchema(prop.schema)) {
                     visible = CliCommonSchema.CodeModel.Visibility.true;
                 }
-                else if (prop.schema instanceof ConstantSchema) {
+                else if (Helper.isConstantSchema(prop.schema)) {
                     // do nothing here
                 }
                 else {
@@ -71,8 +71,8 @@ class VisibilityCleaner {
         });
 
         Helper.enumerateCodeModel(this.session.model, (descriptor) => {
-            if (descriptor.target instanceof Parameter) {
-                if (NodeCliHelper.getIsVisibleFlag(descriptor.target.schema) === CliCommonSchema.CodeModel.Visibility.false) {
+            if (Helper.isParameter(descriptor.target)) {
+                if (NodeCliHelper.getIsVisibleFlag((<Parameter>descriptor.target).schema) === CliCommonSchema.CodeModel.Visibility.false) {
                     NodeCliHelper.setHidden(descriptor.target, true);
                     NodeCliHelper.setIsVisibleFlag(descriptor.target, CliCommonSchema.CodeModel.Visibility.false);
                 }

--- a/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000100-modeler-post-processor-post.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000110-poly-as-resource-pre.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000120-poly-as-resource-post.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000130-flatten-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000130-flatten-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000130-flatten-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000130-flatten-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000130-flatten-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000130-flatten-pre.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000130-flatten-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000130-flatten-pre.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000140-flatten-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000140-flatten-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000140-flatten-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000140-flatten-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000140-flatten-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000140-flatten-post.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000140-flatten-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000140-flatten-post.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000150-modifier-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000150-modifier-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000150-modifier-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000150-modifier-pre-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000150-modifier-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000150-modifier-pre.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000150-modifier-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000150-modifier-pre.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000160-modifier-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000160-modifier-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: system_assigned

--- a/test/scenarios/datafactory/output/clicommon-000160-modifier-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000160-modifier-post-simplified.yaml
@@ -2984,6 +2984,7 @@ schemas:
       - choiceName: factory_identity_type
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: system_assigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000160-modifier-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000160-modifier-post.yaml
@@ -1707,12 +1707,14 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000160-modifier-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000160-modifier-post.yaml
@@ -1707,13 +1707,13 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: factory_identity_type
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000170-namer-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000170-namer-post-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: SystemAssigned

--- a/test/scenarios/datafactory/output/clicommon-000170-namer-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000170-namer-post-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: SystemAssigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000170-namer-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000170-namer-post.yaml
@@ -2256,7 +2256,6 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2265,6 +2264,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000170-namer-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000170-namer-post.yaml
@@ -2256,6 +2256,7 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2264,6 +2265,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: SystemAssigned

--- a/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: SystemAssigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre.yaml
@@ -2256,7 +2256,6 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2265,6 +2264,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000180-complex-marker-pre.yaml
@@ -2256,6 +2256,7 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2264,6 +2265,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
         choiceValues:
           - choiceValue: SystemAssigned

--- a/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post-simplified.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post-simplified.yaml
@@ -3020,6 +3020,7 @@ schemas:
       - choiceName: FactoryIdentityType
         cli:
           cliKey: FactoryIdentityType
+          hidden: true
         choiceValues:
           - choiceValue: SystemAssigned
             cli:

--- a/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post.yaml
@@ -2256,7 +2256,6 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
-      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2265,6 +2264,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          default-value: SystemAssigned
           hidden: true
       protocol: {}
     - &ref_180

--- a/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post.yaml
+++ b/test/scenarios/datafactory/output/clicommon-000190-complex-marker-post.yaml
@@ -2256,6 +2256,7 @@ schemas:
       apiVersions:
         - version: '2018-06-01'
       choiceType: *ref_0
+      defaultValue: SystemAssigned
       language:
         default:
           name: FactoryIdentityType
@@ -2264,6 +2265,7 @@ schemas:
           name: FactoryIdentityType
           description: The identity type. Currently the only supported type is 'SystemAssigned'.
           cliKey: FactoryIdentityType
+          hidden: true
       protocol: {}
     - &ref_180
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000100-modeler-post-processor-post.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000110-poly-as-resource-pre.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000120-poly-as-resource-post.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000130-flatten-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000130-flatten-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000130-flatten-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000130-flatten-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000130-flatten-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000130-flatten-pre.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000130-flatten-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000130-flatten-pre.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000140-flatten-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000140-flatten-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000140-flatten-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000140-flatten-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000140-flatten-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000140-flatten-post.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000140-flatten-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000140-flatten-post.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000150-modifier-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000150-modifier-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000150-modifier-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000150-modifier-pre-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000150-modifier-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000150-modifier-pre.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000150-modifier-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000150-modifier-pre.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000160-modifier-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000160-modifier-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000160-modifier-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000160-modifier-post-simplified.yaml
@@ -851,6 +851,7 @@ schemas:
       - choiceName: kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: connectivity

--- a/test/scenarios/managed-network/output/clicommon-000160-modifier-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000160-modifier-post.yaml
@@ -257,13 +257,13 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000160-modifier-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000160-modifier-post.yaml
@@ -257,12 +257,14 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: kind
           description: Responsibility role under which this Managed Network Group will be created
         cli:
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000170-namer-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000170-namer-post-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: Connectivity

--- a/test/scenarios/managed-network/output/clicommon-000170-namer-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000170-namer-post-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: Connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000170-namer-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000170-namer-post.yaml
@@ -332,6 +332,7 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -340,6 +341,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000170-namer-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000170-namer-post.yaml
@@ -332,7 +332,6 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -341,6 +340,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: Connectivity

--- a/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: Connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre.yaml
@@ -332,6 +332,7 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -340,6 +341,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000180-complex-marker-pre.yaml
@@ -332,7 +332,6 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -341,6 +340,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9

--- a/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
         choiceValues:
           - choiceValue: Connectivity

--- a/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post-simplified.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post-simplified.yaml
@@ -859,6 +859,7 @@ schemas:
       - choiceName: Kind
         cli:
           cliKey: Kind
+          hidden: true
         choiceValues:
           - choiceValue: Connectivity
             cli:

--- a/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post.yaml
@@ -332,6 +332,7 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
+      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -340,6 +341,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          hidden: true
       protocol: {}
     - &ref_9
       choices:

--- a/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post.yaml
+++ b/test/scenarios/managed-network/output/clicommon-000190-complex-marker-post.yaml
@@ -332,7 +332,6 @@ schemas:
       apiVersions:
         - version: 2019-06-01-preview
       choiceType: *ref_0
-      defaultValue: Connectivity
       language:
         default:
           name: Kind
@@ -341,6 +340,7 @@ schemas:
           name: Kind
           description: Responsibility role under which this Managed Network Group will be created
           cliKey: Kind
+          default-value: Connectivity
           hidden: true
       protocol: {}
     - &ref_9


### PR DESCRIPTION
1. Fix m4 change
For m4 change: https://github.com/Azure/autorest.modelerfour/pull/310/files
If `modelAsString` is not true, it will no longer be regarded as constant, but choice. To make it backward compatiable, for those choices which are constant before(choice.length === 1), we give it a default value and set cli hidden as true.

2. Remove instanceof check
In some cases, we cannot get right type in clicommon for example, when integrate with powershell. It might be caused by library conflict. So instanceof might not work as except.