### PR TITLE
Fix flattenedNames issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/clicommon",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "description": "Autorest Azure Cli Common Module",
     "main": "dist/index.js",
     "engines": {

--- a/src/flattener.ts
+++ b/src/flattener.ts
@@ -142,13 +142,13 @@ export class Flattener {
                     // remove that property from the scheama
                     schema.properties.splice(index, 1);
 
-                    // copy all of the properties from the child into this 
-                    // schema 
+                    // copy all of the properties from the child into this schema 
                     for (const childProperty of values(getAllProperties(property.schema))) {
+                        const parentFlattenedNames = property.flattenedNames ?? [property.serializedName];
                         const newProp = new Property(childProperty.language.default.name, childProperty.language.default.description, childProperty.schema, {
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             ...(<any>childProperty),
-                            flattenedNames: [property.serializedName, ...childProperty.flattenedNames ? childProperty.flattenedNames : [childProperty.serializedName]],
+                            flattenedNames: [...parentFlattenedNames, ...childProperty.flattenedNames ? childProperty.flattenedNames : [childProperty.serializedName]],
                             required: property.required && childProperty.required
                         });
                         schema.addProperty(newProp);


### PR DESCRIPTION
Fix the issue: If property has already got flattenedNames, clicommon flatten cannot inherent it.