### PR TITLE
use snake on discriminator flatten prefix

### DIFF
--- a/src/flattener.ts
+++ b/src/flattener.ts
@@ -284,7 +284,7 @@ export class Flattener {
         }
         if (NodeHelper.getJson(subClass) !== true && !NodeCliHelper.isCliFlattened(polyParam)) {
             const path = isNullOrUndefined(polyParam['targetProperty']) ? [] : [polyParam['targetProperty']];
-            FlattenHelper.flattenParameter(request, polyParam, path, `${discriminatorValue}_`);
+            FlattenHelper.flattenParameter(request, polyParam, path, `${Helper.camelToSnake(discriminatorValue)}_`);
             this.onAfterFlatten(polyParam);
         }
     }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -930,4 +930,7 @@ export class Helper {
         return obj; // Return the top-level object to allow chaining
     }
 
+    public static camelToSnake(camel: string): string {
+        return camel.replace(/([A-Z][a-z0-9]+)|([A-Z]+(?=[A-Z][a-z0-9]+))|([A-Z]+$)/g, '_$1$2$3').substr(1).toLowerCase();
+    }
 }

--- a/src/plugins/m4namer.ts
+++ b/src/plugins/m4namer.ts
@@ -142,7 +142,7 @@ export class M4CommonNamer {
         if (!isNullOrUndefined(obj['discriminatorValue'])) {
             const dv: string = obj['discriminatorValue'];
             // dv should be in pascal format, let's do a simple convert to snake
-            const newValue = dv.replace(/([A-Z][a-z0-9]+)|([A-Z]+(?=[A-Z][a-z0-9]+))|([A-Z]+$)/g, '_$1$2$3').substr(1).toLowerCase();
+            const newValue = Helper.camelToSnake(dv);
             NodeCliHelper.setCliDiscriminatorValue(obj, newValue);
         }
 

--- a/src/plugins/namer.ts
+++ b/src/plugins/namer.ts
@@ -216,7 +216,7 @@ export class CommonNamer {
         if (!isNullOrUndefined(obj['discriminatorValue'])) {
             const dv: string = obj['discriminatorValue'];
             // dv should be in pascal format, let's do a simple convert to snake
-            const newValue = dv.replace(/([A-Z][a-z0-9]+)|([A-Z]+(?=[A-Z][a-z0-9]+))|([A-Z]+$)/g, '_$1$2$3').substr(1).toLowerCase();
+            const newValue = Helper.camelToSnake(dv);
             NodeCliHelper.setCliDiscriminatorValue(obj, newValue);
         }
 


### PR DESCRIPTION
For fix issue like bellow in cli codegen:
The LEFT side is before this PR, the RIGHT is after this PR
![image](https://user-images.githubusercontent.com/59815250/120139800-d510aa00-c20b-11eb-8277-4e8951e6257b.png)
